### PR TITLE
Added "play current playlist" option, advanced usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Password
  -v interactive volume control
  -i interactive navigation mode. Accept keyboard keys of Up, Down, Left, Right, Back,
     Context menu and information
+ -l Play current playlist (most useful after using -q a few times)
  -t 'text to send'
  -u Increment the volume on Kodi
  -d Decrement the volume on Kodi

--- a/README.md
+++ b/README.md
@@ -49,3 +49,13 @@ Password
 
 * [mps-youtube](https://github.com/np1/mps-youtube) on the machine running Kodi for the -o option to work.
 
+## Advanced usage
+
+With the addition of a few other tools, most notably
+
+* [youtube-dl](https://github.com/rg3/youtube-dl)
+* [jq](https://github.com/stedolan/jq)
+* [zenity](https://github.com/GNOME/zenity)
+* awk (should be part of your distro).
+
+You can create a dialog to download and sequentially (and with confirmation) play entire playlists - defaulting to your Watch Later playlist - on your Kodi, acting like a kind of remote "casting" program.  See the script **playlist_to_kodi** for an example.

--- a/kodi-cli
+++ b/kodi-cli
@@ -85,6 +85,11 @@ function play_youtube {
     echo " done."
 }
 
+function play_playlist {
+    xbmc_req '{"jsonrpc": "2.0", "method": "Player.Open", "params":{"item":{"playlistid":1, "position" : 0}}, "id": 1}';
+    
+}
+
 function queue_yt_videos {
 
     REGEX="^.*((youtu.be\/)|(v\/)|(\/u\/\w\/)|(embed\/)|(watch\?))\??v?=?([^#\&\?]*).*"
@@ -277,8 +282,11 @@ echo -e "\n kodi-cli -[p|i|h|s|y youtube URL/ID|t 'text to send']\n\n" \
 }
 
 ## Process command line arguments
-while getopts "yqopstiudfhvmnjk" opt; do
+while getopts "yqopstiudfhvmnjkl" opt; do
     case $opt in
+        l)  #play default playlist
+            play_playlist
+            ;;
         y)
             #play youtube video
             play_youtube $2

--- a/kodi-cli
+++ b/kodi-cli
@@ -271,6 +271,7 @@ echo -e "\n kodi-cli -[p|i|h|s|y youtube URL/ID|t 'text to send']\n\n" \
     "-v interactive volume control\n" \
     "-i interactive navigation mode. Accept keyboard keys of Up, Down, Left, Right, Back,\n" \
     "   Context menu and information\n" \
+    "-l Play default playlist (most useful after using -q a few times)\n" \
     "-t 'text to send'\n" \
     "-u Increment the volume on Kodi\n" \
     "-d Decrement the volume on Kodi\n" \

--- a/playlist_to_kodi
+++ b/playlist_to_kodi
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# Required
+# youtube-dl
+# jq
+# curl
+# awk
+# Zenity
+
+# You will need to create a netrc and have a cookies file for youtube-dl
+# Default is your watch later playlist
+
+TEMPFILE=$(mktemp)
+
+szAnswer=$(zenity --timeout 30 --entry --text "What is the playlist URL?" --entry-text ""); echo $szAnswer
+
+if [ -z "$szAnswer" ];then
+    szAnswer=$(echo "https://www.youtube.com/playlist?list=WL")
+fi
+
+youtube-dl "$szAnswer" --netrc --cookies /path/to/cookies.txt --skip-download -j |  tee >(zenity --progress  --title="Fetching playlist" --text="Please be patient..." --pulsate --auto-close --auto-kill)  | jq -M --unbuffered '@text "\(.fulltitle)@@\(.webpage_url)"' > "$TEMPFILE" 
+
+while read line; do
+    vidtitle=$(echo "$line" | awk -F '"' '{print $2}' | awk -F '@@' '{print $1}')
+    zenity --info --timeout=60 --text="Playing $vidtitle"     
+    vidurl=$(echo "$line" | awk -F '"' '{print $2}' | awk -F '@@' '{print $2}') 
+    kodi-cli -y "$vidurl"
+    zenity --info --timeout=60 --text="Marking $vidtitle watched"
+    # Marking video watched
+    #echo "Marking video watched"
+    youtube-dl "$vidurl" --netrc --cookies /path/to/cookies.txt --quiet --skip-download --mark-watched
+    zenity --question --text="Press Yes to continue"
+    if [ $? = 1 ]; then
+        exit
+    fi
+done < "$TEMPFILE"

--- a/playlist_to_kodi
+++ b/playlist_to_kodi
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+# By Steven Saus (uriel1998)
+
 # Required
 # youtube-dl
 # jq
@@ -7,30 +9,44 @@
 # awk
 # Zenity
 
-# You will need to create a netrc and have a cookies file for youtube-dl
-# Default is your watch later playlist
 
 TEMPFILE=$(mktemp)
 
-szAnswer=$(zenity --timeout 30 --entry --text "What is the playlist URL?" --entry-text ""); echo $szAnswer
+if [ -z "$1" ];then
+    szAnswer=$(zenity --timeout 30 --entry --text "What is the playlist URL?" --entry-text ""); echo $szAnswer
+else
+    szAnswer=$(echo "$1")
+fi
 
 if [ -z "$szAnswer" ];then
     szAnswer=$(echo "https://www.youtube.com/playlist?list=WL")
 fi
 
+if [ "$2" == "-nostop" ];then
+    NOSTOP="TRUE"
+fi
+
 youtube-dl "$szAnswer" --netrc --cookies /path/to/cookies.txt --skip-download -j |  tee >(zenity --progress  --title="Fetching playlist" --text="Please be patient..." --pulsate --auto-close --auto-kill)  | jq -M --unbuffered '@text "\(.fulltitle)@@\(.webpage_url)"' > "$TEMPFILE" 
 
 while read line; do
-    vidtitle=$(echo "$line" | awk -F '"' '{print $2}' | awk -F '@@' '{print $1}')
-    zenity --info --timeout=60 --text="Playing $vidtitle"     
-    vidurl=$(echo "$line" | awk -F '"' '{print $2}' | awk -F '@@' '{print $2}') 
-    kodi-cli -y "$vidurl"
-    zenity --info --timeout=60 --text="Marking $vidtitle watched"
-    # Marking video watched
-    #echo "Marking video watched"
-    youtube-dl "$vidurl" --netrc --cookies /path/to/cookies.txt --quiet --skip-download --mark-watched
-    zenity --question --text="Press Yes to continue"
-    if [ $? = 1 ]; then
-        exit
+    if [ -z "$NOSTOP" ];then
+        vidtitle=$(echo "$line" | awk -F '"' '{print $2}' | awk -F '@@' '{print $1}')
+        zenity --info --timeout=60 --text="Playing $vidtitle"     
+        vidurl=$(echo "$line" | awk -F '"' '{print $2}' | awk -F '@@' '{print $2}') 
+        kodi-cli -y "$vidurl"
+        zenity --info --timeout=60 --text="Marking $vidtitle watched"
+        # Marking video watched
+        #echo "Marking video watched"
+        youtube-dl "$vidurl" --netrc --cookies /path/to/cookies.txt --quiet --skip-download --mark-watched
+        zenity --question --text="Press Yes to continue"
+        if [ $? = 1 ]; then
+            exit
+        fi
+    else
+        vidurl=$(echo "$line" | awk -F '"' '{print $2}' | awk -F '@@' '{print $2}') 
+        kodi-cli -q "$vidurl"        
+        youtube-dl "$vidurl" --netrc --cookies /path/to/cookies.txt --quiet --skip-download --mark-watched
     fi
 done < "$TEMPFILE"
+
+kodi-cli -l 


### PR DESCRIPTION
I realized there wasn't a "play current playlist" option, so added that. Also contributed an example of how to use zenity, youtube-dl, and jq to let you play your Watch Later (or other playlist) semi or completely automatically.