### PR TITLE
Add support for password managers

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,17 @@ Username
 Password
 ```
 
+If you don't want to add your kodi passwword, you might leave the password line empty and instead specify a command invocation in the next line that returns your password on stdout.
+
+
+```
+The Kodi Host
+The port Kodi listens on (the webserver port)
+Username
+
+Commannd invocation that returns the password on stdout (e.g. pass mykodibox/kodi)
+```
+
 ## Arguments
 ```
  -p Play/Pause the current played video

--- a/kodi-cli
+++ b/kodi-cli
@@ -294,6 +294,7 @@ if [ -z "$KODI_HOST" ]; then
         KODI_PORT=${line[1]}
         KODI_USER=${line[2]}
         KODI_PASS=${line[3]}
+	KODI_PASSWORD_COMMAND=${line[4]}
     fi
 fi
 
@@ -302,6 +303,11 @@ if [ -z "$KODI_HOST" ]; then
 	echo -e "\n failure: Some Kodi configurations are not loaded. Please make sure they are."
 	show_help
 	exit
+fi
+
+#Run an external command to fetch the password if neccessary.
+if [ -z "$KODI_PASS" ] && [ -n "$KODI_PASSWORD_COMMAND" ]; then
+    KODI_PASS=$($KODI_PASSWORD_COMMAND)
 fi
 
 ## Process command line arguments


### PR DESCRIPTION
I don't like passwords just lying in my home directory, so I added support for pass.

In order to not break current installations, I decided that an empty password line should be a marker that the next line contains a command that prints the password to stdout. For most users it's probably an invocation of pass, so I added that as an example.