### PR TITLE
Add switch to pipe text from stdin directly to kodi.

### DIFF
--- a/kodi-cli
+++ b/kodi-cli
@@ -127,6 +127,12 @@ function send_text {
     xbmc_req '{"jsonrpc": "2.0", "method": "Input.SendText", "params": { "text": "'$1'" }}'
 }
 
+function pipe_text {
+    while IFS= read -r input; do
+	xbmc_req '{"jsonrpc": "2.0", "method": "Input.SendText", "params": { "text": "'$input'" }}'
+    done
+}
+
 function update_libraries {
     echo "Updating the video libraries"
     xbmc_req '{"jsonrpc": "2.0", "method": "VideoLibrary.Scan", "id": "mybash"}'
@@ -253,6 +259,7 @@ echo -e "\n kodi-cli -[p|i|h|s|y youtube URL/ID|t 'text to send']\n\n" \
     "   Context menu and information\n" \
     "-l Play default playlist (most useful after using -q a few times)\n" \
     "-t 'text to send'\n" \
+    "-r Send text from stdin to kodi\n" \
     "-u Increment the volume on Kodi\n" \
     "-d Decrement the volume on Kodi\n" \
     "-x Mute/Unmute the volume on Kodi\n" \
@@ -311,7 +318,7 @@ if [ -z "$KODI_PASS" ] && [ -n "$KODI_PASSWORD_COMMAND" ]; then
 fi
 
 ## Process command line arguments
-while getopts "yqopstiudfhvmnjklx" opt; do
+while getopts "yqoprstiudfhvmnjklx" opt; do
     case $opt in
         l)  #play default playlist
             play_playlist
@@ -335,6 +342,10 @@ while getopts "yqopstiudfhvmnjklx" opt; do
         s)
             stop
             ;;
+	r)
+	    pipe_text
+	    ;;
+
         t)  
             send_text $2
             handle_keys


### PR DESCRIPTION
I'm back with a stdin PR :-)

I wanted to send output of a program to kodi but really didn't feel like using my mouse to selecting and copying text, so I wrote a function to read from stdin and send to kodi. I chose `-r` as a parameter, because it was still free, so please suggest something if you have any better ideas, but everything I could think of that would make sense was already used by something else.

Example usage `echo "star wars" | kodi-cli -r` will send the String `star wars` to kodi.
More interesting when you want to do sth. like `pass my-streaming-service-password | kodi-cli -r`, because this keeps the password out of the process list.