### PR TITLE
Updated skip_forward and skip_backward function in compliance to new APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,18 +37,20 @@ Commannd invocation that returns the password on stdout (e.g. pass mykodibox/kod
 ```
  -p Play/Pause the current played video
  -s Stop the current played video
- -j Skip forward in the current played video     
- -k Skip backward in the current played video     
- -y Play YouTube video. Use either URL/ID (of video)
- -q Queue YouTube video to the current list. Use either URL/ID (of video). Use instead of -y.
- -o Play YouTube video directly on Kodi. Use the name of video.
+ -j Skip forward in the current played video by 10 seconds. Use -j <seconds> to specify custom time)
+ -k Skip backward in the current played video by 10 seconds. Use -k <seconds> to specify custom time)
+ -y Play youtube video. Use either URL/ID (of video)
+ -q Queue youtube video to the current list. Use either URL/ID (of video). Use instead of -y.
+ -o Play youtube video directly on Kodi. Use the name of video.
  -v Interactive volume control
  -i Interactive navigation mode. Accept keyboard keys of Up, Down, Left, Right, Back,
     Context menu and information
- -l Play current playlist (most useful after using -q a few times)
+ -l Play default playlist (most useful after using -q a few times)
  -t 'text to send'
+ -r Send text from stdin to kodi
  -u Increment the volume on Kodi
  -d Decrement the volume on Kodi
+ -x Mute/Unmute the volume on Kodi
  -f Toggle fullscreen
  -m Update libraries
  -n Clean libraries

--- a/kodi-cli
+++ b/kodi-cli
@@ -106,20 +106,25 @@ function stop {
     xbmc_req '{"jsonrpc": "2.0", "method": "Player.Stop", "params": { "playerid": '$player_id' }, "id": 1}'
 }
 
+function skip_time {
+    local seconds=${1:-10}  # Default to 10 seconds if not provided
+    echo $seconds
+}
+
 function skip_forward {
-    # Get Active players first
-    output=`xbmc_req '{"jsonrpc": "2.0", "method": "Player.GetActivePlayers", "id": 99}' true`
-    player_id=`echo $output | parse_json "playerid"`
-    echo "Skipping forward the player with ID => $player_id"
-    xbmc_req '{"jsonrpc": "2.0", "method": "Player.Seek", "params": { "playerid": '$player_id', "value" : "smallforward" }, "id": 1}'
+    local seconds=$(skip_time $1)
+    output=$(xbmc_req '{"jsonrpc": "2.0", "method": "Player.GetActivePlayers", "id": 99}' true)
+    player_id=$(echo "$output" | parse_json "playerid")
+    echo "Skipping forward the player with ID => $player_id for $seconds seconds"
+    xbmc_req '{"jsonrpc": "2.0", "method": "Player.Seek", "params": { "playerid": '$player_id', "value" : { "seconds": '$seconds' } }, "id": 1}'
 }
 
 function skip_backward {
-    # Get Active players first
-    output=`xbmc_req '{"jsonrpc": "2.0", "method": "Player.GetActivePlayers", "id": 99}' true`
-    player_id=`echo $output | parse_json "playerid"`
-    echo "Skipping back with the player with ID => $player_id"
-    xbmc_req '{"jsonrpc": "2.0", "method": "Player.Seek", "params": { "playerid": '$player_id', "value" : "smallbackward" }, "id": 1}'
+    local seconds=$(skip_time $1)
+    output=$(xbmc_req '{"jsonrpc": "2.0", "method": "Player.GetActivePlayers", "id": 99}' true)
+    player_id=$(echo "$output" | parse_json "playerid")
+    echo "Skipping back with the player with ID => $player_id for $seconds seconds"
+    xbmc_req '{"jsonrpc": "2.0", "method": "Player.Seek", "params": { "playerid": '$player_id', "value" : { "seconds": -'$seconds' } }, "id": 1}'
 }
 
 function send_text {
@@ -249,8 +254,8 @@ function show_help {
 echo -e "\n kodi-cli -[p|i|h|s|y youtube URL/ID|t 'text to send']\n\n" \
     "-p Play/Pause the current played video\n" \
     "-s Stop the current played video\n" \
-    "-j Skip forward in the current played video\n" \
-    "-k Skip backward in the current played video\n" \
+    "-j Skip forward in the current played video by 10 seconds. Use -j <seconds> to specify custom time)\n" \
+    "-k Skip backward in the current played video by 10 seconds. Use -k <seconds> to specify custom time)\n" \
     "-y Play youtube video. Use either URL/ID (of video)\n" \
     "-q Queue youtube video to the current list. Use either URL/ID (of video). Use instead of -y.\n" \
     "-o Play youtube video directly on Kodi. Use the name of video.\n" \
@@ -318,7 +323,7 @@ if [ -z "$KODI_PASS" ] && [ -n "$KODI_PASSWORD_COMMAND" ]; then
 fi
 
 ## Process command line arguments
-while getopts "yqoprstiudfhvmnjklx" opt; do
+while getopts "yqoprstiudfhvmnj:k:l:x" opt; do
     case $opt in
         l)  #play default playlist
             play_playlist
@@ -342,10 +347,9 @@ while getopts "yqoprstiudfhvmnjklx" opt; do
         s)
             stop
             ;;
-	r)
-	    pipe_text
-	    ;;
-
+        r)
+            pipe_text
+            ;;
         t)  
             send_text $2
             handle_keys
@@ -375,14 +379,13 @@ while getopts "yqoprstiudfhvmnjklx" opt; do
             handle_volume
             ;;
         j)
-            skip_forward
+            skip_forward $OPTARG  # Pass the value of seconds to skip
             ;;
         k)
-            skip_backward
+            skip_backward $OPTARG  # Pass the value of seconds to skip
             ;;
         x)
             volume_mute
             ;;
-
     esac
 done


### PR DESCRIPTION
In the previous code, parameters were passed as strings with the values "smallforward" and "smallbackward". This may have been the format expected by older versions of Kodi, but recent versions expect the value to be an object specifying the number of seconds to skip. This commit corrects this problem. That said, thank you for your project, which I find very convenient. 